### PR TITLE
Fix "API Update Required" notice due to deprecated BuildTarget.iPhone

### DIFF
--- a/unity/Assets/Editor/URLClient/URLClientPostprocessor.cs
+++ b/unity/Assets/Editor/URLClient/URLClientPostprocessor.cs
@@ -38,7 +38,7 @@ public class URLClientPostprocessor : Editor
     #if UNITY_5
     if (target != BuildTarget.iOS)
     #else
-    if (target != BuildTArget.iPhone)
+    if (target != BuildTarget.iPhone)
     #endif
     {
       return;

--- a/unity/Assets/Editor/URLClient/URLClientPostprocessor.cs
+++ b/unity/Assets/Editor/URLClient/URLClientPostprocessor.cs
@@ -35,7 +35,7 @@ public class URLClientPostprocessor : Editor
   public static void OnPostprocessBuild(BuildTarget target,
       string pathToBuildProject)
   {
-    if (target != BuildTarget.iPhone)
+    if (target != BuildTarget.iOS)
     {
       return;
     }

--- a/unity/Assets/Editor/URLClient/URLClientPostprocessor.cs
+++ b/unity/Assets/Editor/URLClient/URLClientPostprocessor.cs
@@ -35,10 +35,10 @@ public class URLClientPostprocessor : Editor
   public static void OnPostprocessBuild(BuildTarget target,
       string pathToBuildProject)
   {
-    #if UNITY_5
-    if (target != BuildTarget.iOS)
-    #else
+    #if UNITY_3 || UNITY_4
     if (target != BuildTarget.iPhone)
+    #else
+    if (target != BuildTarget.iOS)
     #endif
     {
       return;

--- a/unity/Assets/Editor/URLClient/URLClientPostprocessor.cs
+++ b/unity/Assets/Editor/URLClient/URLClientPostprocessor.cs
@@ -35,7 +35,11 @@ public class URLClientPostprocessor : Editor
   public static void OnPostprocessBuild(BuildTarget target,
       string pathToBuildProject)
   {
+    #if UNITY_5
     if (target != BuildTarget.iOS)
+    #else
+    if (target != BuildTArget.iPhone)
+    #endif
     {
       return;
     }


### PR DESCRIPTION
The "API Update Required" popup is appearing on import, and `BuildTarget.iPhone` seems to be the cause:

```
Assets/Editor/URLClient/URLClientPostprocessor.cs(38,31): error CS0619: `UnityEditor.BuildTarget.iPhone' is obsolete: `Use iOS instead (UnityUpgradable) -> iOS'
```
